### PR TITLE
Adds voice changer

### DIFF
--- a/cartesia/_types.py
+++ b/cartesia/_types.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TypedDict, Union
+from typing import List, Literal, Optional, TypedDict, Union
 
 from cartesia.utils.deprecated import deprecated
 
@@ -91,10 +91,40 @@ class VoiceControls(TypedDict):
     emotion: List[str] = []
 
 
-class OutputFormat(TypedDict):
-    container: str
+class MP3Format(TypedDict):
+    container: Literal["mp3"]
+    bit_rate: int
+    sample_rate: int
+
+class WAVFormat(TypedDict):
+    container: Literal["wav"]
     encoding: str
     sample_rate: int
+    bit_rate: int
+
+class RawFormat(TypedDict):
+    container: Literal["raw"]
+    encoding: str
+    sample_rate: int
+
+StrictOutputFormat = Union[MP3Format, WAVFormat, RawFormat]
+
+class OutputFormat():
+    def __new__(cls, **kwargs):
+        if kwargs["container"] == "mp3":
+            if {"bit_rate", "sample_rate"} != kwargs.keys():
+                raise ValueError("mp3 container requires bit_rate and sample_rate")
+            return MP3Format(**kwargs)
+        elif kwargs["container"] == "wav":
+            if {"encoding", "sample_rate", "bit_rate"} != kwargs.keys():
+                raise ValueError("wav container requires encoding, sample_rate, and bit_rate")
+            return WAVFormat(**kwargs)
+        elif kwargs["container"] == "raw":
+            if {"encoding", "sample_rate"} != kwargs.keys():
+                raise ValueError("raw container requires encoding and sample_rate")
+            return RawFormat(**kwargs)
+        else:
+            raise ValueError(f"Unsupported container: '{kwargs['container']}'")
 
 
 class EventType:

--- a/cartesia/client.py
+++ b/cartesia/client.py
@@ -4,6 +4,7 @@ from typing import Optional, Union
 
 from cartesia._constants import DEFAULT_BASE_URL, DEFAULT_TIMEOUT
 from cartesia.tts import TTS
+from cartesia.voice_changer import VoiceChanger
 from cartesia.voices import Voices
 
 
@@ -56,6 +57,7 @@ class Cartesia(BaseClient):
         super().__init__(api_key=api_key, base_url=base_url, timeout=timeout)
         self.voices = Voices(api_key=self.api_key, base_url=self._base_url, timeout=self.timeout)
         self.tts = TTS(api_key=self.api_key, base_url=self._base_url, timeout=self.timeout)
+        self.voice_changer = VoiceChanger(api_key=self.api_key, base_url=self._base_url, timeout=self.timeout)
 
     def __enter__(self):
         return self

--- a/cartesia/voice_changer.py
+++ b/cartesia/voice_changer.py
@@ -1,0 +1,54 @@
+import httpx
+
+from cartesia._types import OutputFormat
+from cartesia.resource import Resource
+
+class VoiceChanger(Resource):
+    def change_voice_file(
+        self,
+        input_path: str,
+        voice_id: str,
+        output_format: OutputFormat,
+        output_path: str,
+    ) -> None:
+        url = f"{self._http_url()}/voice-changer/bytes"
+        with open(input_path, "rb") as input_file:
+            headers = self.headers.copy()
+            headers.pop("Content-Type", None)
+            files = {"clip": input_file}
+            data = {
+                "voice[id]": voice_id,
+                "output_format[container]": output_format["container"]
+						}
+            
+            if "encoding" in output_format:
+                data["output_format[encoding]"] = output_format["encoding"]
+            if "sample_rate" in output_format:
+                data["output_format[sample_rate]"] = output_format["sample_rate"]
+            if "bit_rate" in output_format:
+                data["output_format[bit_rate]"] = output_format["bit_rate"]
+
+            response = httpx.post(url, headers=headers, files=files, data=data, timeout=self.timeout)
+            if not response.is_success:
+                raise ValueError(f"Failed to change voice in clip. Error: {response.text}")
+
+        with open(output_path, "wb") as output_file:
+            output_file.write(response.content)
+
+    def change_voice_bytes(self, audio_blob: bytes, voice_id: str, output_format: OutputFormat) -> bytes:
+        url = f"{self._http_url()}/voice-changer/bytes"
+        headers = self.headers.copy()
+        headers.pop("Content-Type", None)
+        files = {"clip": audio_blob}
+        data = {
+            "voice[id]": voice_id,
+            "output_format[container]": output_format["container"],
+            "output_format[encoding]": output_format["encoding"],
+            "output_format[sample_rate]": output_format["sample_rate"],
+        }
+
+        response = httpx.post(url, headers=headers, files=files, data=data, timeout=self.timeout)
+        if not response.is_success:
+            raise ValueError(f"Failed to change voice in clip. Error: {response.text}")
+
+        return response.content

--- a/cartesia/voice_changer.py
+++ b/cartesia/voice_changer.py
@@ -1,6 +1,6 @@
 import httpx
 
-from cartesia._types import OutputFormat
+from cartesia._types import StrictOutputFormat
 from cartesia.resource import Resource
 
 class VoiceChanger(Resource):
@@ -8,34 +8,15 @@ class VoiceChanger(Resource):
         self,
         input_path: str,
         voice_id: str,
-        output_format: OutputFormat,
+        output_format: StrictOutputFormat,
         output_path: str,
     ) -> None:
-        url = f"{self._http_url()}/voice-changer/bytes"
         with open(input_path, "rb") as input_file:
-            headers = self.headers.copy()
-            headers.pop("Content-Type", None)
-            files = {"clip": input_file}
-            data = {
-                "voice[id]": voice_id,
-                "output_format[container]": output_format["container"]
-						}
-            
-            if "encoding" in output_format:
-                data["output_format[encoding]"] = output_format["encoding"]
-            if "sample_rate" in output_format:
-                data["output_format[sample_rate]"] = output_format["sample_rate"]
-            if "bit_rate" in output_format:
-                data["output_format[bit_rate]"] = output_format["bit_rate"]
-
-            response = httpx.post(url, headers=headers, files=files, data=data, timeout=self.timeout)
-            if not response.is_success:
-                raise ValueError(f"Failed to change voice in clip. Error: {response.text}")
-
+            content = self.change_voice_bytes(input_file, voice_id, output_format)
         with open(output_path, "wb") as output_file:
-            output_file.write(response.content)
+            output_file.write(content)
 
-    def change_voice_bytes(self, audio_blob: bytes, voice_id: str, output_format: OutputFormat) -> bytes:
+    def change_voice_bytes(self, audio_blob: bytes, voice_id: str, output_format: StrictOutputFormat) -> bytes:
         url = f"{self._http_url()}/voice-changer/bytes"
         headers = self.headers.copy()
         headers.pop("Content-Type", None)
@@ -43,9 +24,14 @@ class VoiceChanger(Resource):
         data = {
             "voice[id]": voice_id,
             "output_format[container]": output_format["container"],
-            "output_format[encoding]": output_format["encoding"],
-            "output_format[sample_rate]": output_format["sample_rate"],
         }
+	
+        if "encoding" in output_format:
+            data["output_format[encoding]"] = output_format["encoding"]
+        if "sample_rate" in output_format:
+            data["output_format[sample_rate]"] = output_format["sample_rate"]
+        if "bit_rate" in output_format:
+            data["output_format[bit_rate]"] = output_format["bit_rate"]
 
         response = httpx.post(url, headers=headers, files=files, data=data, timeout=self.timeout)
         if not response.is_success:


### PR DESCRIPTION
## Summary

Adds:
- `Cartesia.voice_changer.change_voice_bytes`, which takes raw bytes
- `Cartesia.voice_changer.change_voice_file`, which takes filepaths for in/out and handles file writing

This change also adds some type trickery for `OutputFormat`, which I'm not 100% convinced is good. Namely: if we're doing runtime validation for `OutputFormat`, then it's not clear that the type guarantees of `StrictOutputFormat` really buy us that much.

## Remaining work

- [ ] add docstrings
- [ ] think more about `OutputFormat`, `StrictOutputFormat`, `MP3Format`, `WAVFormat`, and `RawFormat` — if we like this, I have to update internal usage from `OutputFormat` to `StrictOutputFormat`, but maybe this isn't actually worth it