### PR TITLE
Rely on PyPI Trusted Publisher for publishing instead of using token

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,8 +8,6 @@ on:
       # this also allows us to run the workflow manually without skipping.
       - "cartesia/version.py"
 
-  pull_request:
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,8 @@ on:
       # this also allows us to run the workflow manually without skipping.
       - "cartesia/version.py"
 
+  pull_request:
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -41,8 +43,6 @@ jobs:
 
       - name: Publish to PyPI
         run: uv publish
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Get version
         run: |


### PR DESCRIPTION
Fixes publishing not working