### PR TITLE
Websocket support for word_timestamps that don't have the 'data' field

### DIFF
--- a/cartesia/_websocket.py
+++ b/cartesia/_websocket.py
@@ -121,7 +121,7 @@ class _TTSContext:
                         raise RuntimeError(f"Error generating audio:\n{response['error']}")
                     if response["done"]:
                         break
-                    if response["data"]:
+                    if "data" in response and response["data"]:
                         yield self._websocket._convert_response(
                             response=response, include_context_id=True
                         )
@@ -138,7 +138,7 @@ class _TTSContext:
                             raise RuntimeError(f"Error generating audio:\n{response['error']}")
                         if response["done"]:
                             break
-                        if response["data"]:
+                        if "data" in response and response["data"]:
                             yield self._websocket._convert_response(
                                 response=response, include_context_id=True
                             )


### PR DESCRIPTION
This is a fix for this issue #18 

It provides a simple safety check for the presence of the "data" field in a response before trying to access it.