### PR TITLE
Update uv.lock using `uv sync`

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -162,8 +162,8 @@ wheels = [
 
 [[package]]
 name = "cartesia"
-version = "1.2.0"
-source = { virtual = "." }
+version = "1.4.0"
+source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
     { name = "httpx" },
@@ -172,7 +172,7 @@ dependencies = [
     { name = "websockets" },
 ]
 
-[package.dev-dependencies]
+[package.dependency-groups]
 dev = [
     { name = "isort" },
     { name = "numpy" },
@@ -189,13 +189,13 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.10.10" },
-    { name = "httpx", specifier = ">=0.27.2" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "iterators", specifier = ">=0.2.0" },
-    { name = "requests", specifier = ">=2.32.3" },
-    { name = "websockets", specifier = ">=13.1" },
+    { name = "requests", specifier = ">=2.31.0" },
+    { name = "websockets", specifier = ">=10.4" },
 ]
 
-[package.metadata.requires-dev]
+[package.metadata.dependency-groups]
 dev = [
     { name = "isort", specifier = ">=5.13.2" },
     { name = "numpy", specifier = ">=2.0.2" },


### PR DESCRIPTION
Updates lockfile to the latest uv format. In 0.4.27, uv started supporting the dependency-groups package metadata specifier (https://raw.githubusercontent.com/astral-sh/uv/main/CHANGELOG.md), so this updates to that format.

There are some changes, such as resolving websockets to >=10.4, that make it more closely track the dependencies that we have specified in pyproject.toml.

In any case, this file is transparent to us.