### PR TITLE
Add phonemized timestamps to websocket `send` calls

### DIFF
--- a/src/cartesia/tts/_async_websocket.py
+++ b/src/cartesia/tts/_async_websocket.py
@@ -428,8 +428,8 @@ class AsyncTtsWebsocket(TtsWebsocket):
             phoneme_timestamps=(
                 PhonemeTimestamps(
                     phonemes=phonemes,
-                    start=start,
-                    end=end,
+                    start=phoneme_start,
+                    end=phoneme_end,
                 )
                 if add_phoneme_timestamps
                 else None

--- a/src/cartesia/tts/_async_websocket.py
+++ b/src/cartesia/tts/_async_websocket.py
@@ -17,6 +17,7 @@ from cartesia.tts.types import (
     WebSocketResponse_FlushDone,
     WebSocketTtsOutput,
     WordTimestamps,
+    PhonemeTimestamps,
 )
 
 from ..core.pydantic_utilities import parse_obj_as
@@ -67,6 +68,7 @@ class _AsyncTTSContext:
         language: Optional[str] = None,
         stream: bool = True,
         add_timestamps: bool = False,
+        add_phoneme_timestamps: bool = False,
         continue_: bool = False,
         flush: bool = False,
     ) -> None:
@@ -102,6 +104,8 @@ class _AsyncTTSContext:
             request_body["stream"] = stream
         if add_timestamps:
             request_body["add_timestamps"] = add_timestamps
+        if add_phoneme_timestamps:
+            request_body["add_phoneme_timestamps"] = add_phoneme_timestamps
         if continue_:
             request_body["continue"] = continue_
         if flush:
@@ -362,6 +366,7 @@ class AsyncTtsWebsocket(TtsWebsocket):
         language: Optional[str] = None,
         stream: bool = True,
         add_timestamps: bool = False,
+        add_phoneme_timestamps: bool = False,
     ):
         """See :meth:`_WebSocket.send` for details."""
         if context_id is None:
@@ -379,6 +384,7 @@ class AsyncTtsWebsocket(TtsWebsocket):
             language=language,
             continue_=False,
             add_timestamps=add_timestamps,
+            add_phoneme_timestamps=add_phoneme_timestamps,
         )
 
         generator = ctx.receive()
@@ -390,6 +396,9 @@ class AsyncTtsWebsocket(TtsWebsocket):
         words: typing.List[str] = []
         start: typing.List[float] = []
         end: typing.List[float] = []
+        phonemes: typing.List[str] = []
+        phoneme_start: typing.List[float] = []
+        phoneme_end: typing.List[float] = []
         async for chunk in generator:
             if chunk.audio is not None:
                 chunks.append(chunk.audio)
@@ -398,6 +407,11 @@ class AsyncTtsWebsocket(TtsWebsocket):
                     words.extend(chunk.word_timestamps.words)
                     start.extend(chunk.word_timestamps.start)
                     end.extend(chunk.word_timestamps.end)
+            if add_phoneme_timestamps and chunk.phoneme_timestamps is not None:
+                if chunk.phoneme_timestamps is not None:
+                    phonemes.extend(chunk.phoneme_timestamps.phonemes)
+                    phoneme_start.extend(chunk.phoneme_timestamps.start)
+                    phoneme_end.extend(chunk.phoneme_timestamps.end)
 
         return WebSocketTtsOutput(
             audio=b"".join(chunks),  # type: ignore
@@ -409,6 +423,15 @@ class AsyncTtsWebsocket(TtsWebsocket):
                     end=end,
                 )
                 if add_timestamps
+                else None
+            ),
+            phoneme_timestamps=(
+                PhonemeTimestamps(
+                    phonemes=phonemes,
+                    start=start,
+                    end=end,
+                )
+                if add_phoneme_timestamps
                 else None
             ),
         )

--- a/src/cartesia/tts/_websocket.py
+++ b/src/cartesia/tts/_websocket.py
@@ -330,6 +330,8 @@ class TtsWebsocket:
             out["audio"] = base64.b64decode(response.data)
         elif isinstance(response, WebSocketResponse_Timestamps):
             out["word_timestamps"] = response.word_timestamps  # type: ignore
+        elif isinstance(response, WebSocketResponse_PhonemeTimestamps):
+            out["phoneme_timestamps"] = response.phoneme_timestamps  # type: ignore
         elif include_flush_id and isinstance(response, WebSocketResponse_FlushDone):
             out["flush_done"] = response.flush_done  # type: ignore
             out["flush_id"] = response.flush_id  # type: ignore

--- a/src/cartesia/tts/_websocket.py
+++ b/src/cartesia/tts/_websocket.py
@@ -26,6 +26,7 @@ from cartesia.tts.types import (
     WebSocketResponse_Timestamps,
     WebSocketTtsOutput,
     WordTimestamps,
+    PhonemeTimestamps,
 )
 
 from ..core.pydantic_utilities import parse_obj_as
@@ -350,6 +351,7 @@ class TtsWebsocket:
         language: Optional[str] = None,
         stream: bool = True,
         add_timestamps: bool = False,
+        add_phoneme_timestamps: bool = False,
     ):
         """Send a request to the WebSocket to generate audio.
 
@@ -379,6 +381,7 @@ class TtsWebsocket:
             "language": language,
             "stream": stream,
             "add_timestamps": add_timestamps,
+            "add_phoneme_timestamps": add_phoneme_timestamps,
         }
         generator = self._websocket_generator(request_body)
 
@@ -389,6 +392,9 @@ class TtsWebsocket:
         words: typing.List[str] = []
         start: typing.List[float] = []
         end: typing.List[float] = []
+        phonemes: typing.List[str] = []
+        phoneme_start: typing.List[float] = []
+        phoneme_end: typing.List[float] = []
         for chunk in generator:
             if chunk.audio is not None:
                 chunks.append(chunk.audio)
@@ -397,6 +403,11 @@ class TtsWebsocket:
                     words.extend(chunk.word_timestamps.words)
                     start.extend(chunk.word_timestamps.start)
                     end.extend(chunk.word_timestamps.end)
+            if add_phoneme_timestamps and chunk.phoneme_timestamps is not None:
+                if chunk.phoneme_timestamps is not None:
+                    phonemes.extend(chunk.phoneme_timestamps.phonemes)
+                    phoneme_start.extend(chunk.phoneme_timestamps.start)
+                    phoneme_end.extend(chunk.phoneme_timestamps.end)
 
         return WebSocketTtsOutput(
             audio=b"".join(chunks),  # type: ignore
@@ -408,6 +419,15 @@ class TtsWebsocket:
                     end=end,
                 )
                 if add_timestamps
+                else None
+            ),
+            phoneme_timestamps=(
+                PhonemeTimestamps(
+                    phonemes=phonemes,
+                    start=phoneme_start,
+                    end=phoneme_end,
+                )
+                if add_phoneme_timestamps
                 else None
             ),
         )


### PR DESCRIPTION
- Modifies `_websocket` and `_async_websocket` to support phoneme timestamps
- Adds unit tests that checks that we're receiving phoneme timestamps


We just set `add_phoneme_timestamps=True` and aggregate the timestamps as follows:
```
output_generate = ws.send(
        transcript=transcript,
        voice={"mode": "id", "id": SAMPLE_VOICE_ID},
        output_format=DEFAULT_OUTPUT_FORMAT_PARAMS,
        model_id=DEFAULT_MODEL_ID,
        add_phoneme_timestamps=True,
        stream=True,
    )

chunks = []
all_phonemes = []
all_starts = []
all_ends = []
for out in output_generate:
    assert out.context_id is not None
    if out.phoneme_timestamps is not None:
        all_phonemes.extend(out.phoneme_timestamps.phonemes)
        all_starts.extend(out.phoneme_timestamps.start)
        all_ends.extend(out.phoneme_timestamps.end)
    if out.audio is not None:
        chunks.append(out.audio)
```
