### PR TITLE
Return from `_TTSContext` after receiving DONE

### DIFF
--- a/src/cartesia/tts/_websocket.py
+++ b/src/cartesia/tts/_websocket.py
@@ -154,7 +154,7 @@ class _TTSContext:
                             f"Error generating audio:\n{response_obj.error}"
                         )
                     if isinstance(response_obj, WebSocketResponse_Done):
-                        break
+                        return
                     if (
                         isinstance(response_obj, WebSocketResponse_Chunk)
                         or isinstance(response_obj, WebSocketResponse_Timestamps)
@@ -185,7 +185,7 @@ class _TTSContext:
                                 f"Error generating audio:\n{response_obj.error}"
                             )
                         if isinstance(response_obj, WebSocketResponse_Done):
-                            break
+                            return
                         if (
                             isinstance(response_obj, WebSocketResponse_Chunk)
                             or isinstance(response_obj, WebSocketResponse_Timestamps)
@@ -221,7 +221,7 @@ class _TTSContext:
                 if isinstance(response_obj, WebSocketResponse_Error):
                     raise RuntimeError(f"Error generating audio:\n{response_obj.error}")
                 if isinstance(response_obj, WebSocketResponse_Done):
-                    break
+                    return
                 yield self._websocket._convert_response(
                     response_obj, include_context_id=True
                 )


### PR DESCRIPTION
For the synchronous continuations client, there's an edge case where receiving a DONE message without sending `no_more_inputs()` can lead to the websocket hanging for 5 minutes. In order to fix this, we return from the WebSocket `send` as soon as we receive a DONE message.

## Testing

Before changes

```
🚀 Testing Cartesia TTS Sync Continuations
Sending 3 transcript chunks...
Yielding transcript Hello, world! 
Received audio chunk 1: 16384 bytes
Received audio chunk 2: 16384 bytes
Received audio chunk 3: 16384 bytes
Received audio chunk 4: 16384 bytes
Received audio chunk 5: 16384 bytes
Received audio chunk 6: 16384 bytes
Received audio chunk 7: 16384 bytes
Received audio chunk 8: 16384 bytes
Received audio chunk 9: 16384 bytes
Received audio chunk 10: 16384 bytes
Received audio chunk 11: 16384 bytes
Received audio chunk 12: 16384 bytes
Received audio chunk 13: 16384 bytes
Received audio chunk 14: 16384 bytes
Received audio chunk 15: 16384 bytes
❌ Test failed: Failed to generate audio. received 1000 (OK) connection idle timeout; then sent 1000 (OK) connection idle timeout
Traceback (most recent call last):
  File "/Users/sauhard.jain/code/cartesia-python/src/cartesia/tts/_websocket.py", line 177, in send
    self._websocket.websocket.recv(timeout=0.001)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/sauhard.jain/code/cartesia-python/.venv/lib/python3.13/site-packages/websockets/sync/connection.py", line 336, in recv
    raise self.protocol.close_exc from self.recv_exc
websockets.exceptions.ConnectionClosedOK: received 1000 (OK) connection idle timeout; then sent 1000 (OK) connection idle timeout

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sauhard.jain/code/cartesia-python/test_sync_continuations.py", line 95, in <module>
    main()
    ~~~~^^
  File "/Users/sauhard.jain/code/cartesia-python/test_sync_continuations.py", line 70, in main
    for out in output_generate:
               ^^^^^^^^^^^^^^^
  File "/Users/sauhard.jain/code/cartesia-python/src/cartesia/tts/_websocket.py", line 232, in send
    raise RuntimeError(f"Failed to generate audio. {e}")
RuntimeError: Failed to generate audio. received 1000 (OK) connection idle timeout; then sent 1000 (OK) connection idle timeout
```

After changes

```
🚀 Testing Cartesia TTS Sync Continuations
⏱️  Starting timer at 1748391405.217
Creating WebSocket connection...
WebSocket created in 0.247 seconds
Creating context...
Context created in 0.000 seconds
Sending 3 transcript chunks...
Yielding transcript Hello, world! 
⏱️  First audio chunk received at 0.486 seconds from start
Received audio chunk 1: 16384 bytes at 0.486s
Received audio chunk 2: 16384 bytes at 0.529s
Received audio chunk 3: 16384 bytes at 0.532s
Received audio chunk 4: 16384 bytes at 0.536s
Received audio chunk 5: 16384 bytes at 0.570s
Received audio chunk 6: 16384 bytes at 0.601s
Received audio chunk 7: 16384 bytes at 0.639s
Received audio chunk 8: 16384 bytes at 0.686s
Received audio chunk 9: 16384 bytes at 0.719s
Received audio chunk 10: 16384 bytes at 0.754s
Received audio chunk 11: 16384 bytes at 0.789s
Received audio chunk 12: 16384 bytes at 0.829s

============================================================
⏱️  TIMING SUMMARY:
WebSocket creation: 0.247 seconds
Context creation: 0.000 seconds
Time to first chunk: 0.486 seconds
Time to last chunk: 0.829 seconds
Total time (WebSocket → Success): 6.361 seconds
============================================================
✅ Success! Generated 196608 bytes of audio from 12 chunks
```