### PR TITLE
[BIF-1595] Fixes spurious close errors in `_process_responses`

### DIFF
--- a/src/cartesia/tts/_websocket.py
+++ b/src/cartesia/tts/_websocket.py
@@ -46,7 +46,6 @@ class _TTSContext:
     def __init__(self, context_id: str, websocket: "TtsWebsocket"):
         self._context_id = context_id
         self._websocket = websocket
-        self._error = None
 
     def __del__(self):
         self._close()

--- a/tests/custom/test_client.py
+++ b/tests/custom/test_client.py
@@ -61,7 +61,6 @@ EXPERIMENTAL_VOICE_CONTROLS = {
 }
 EXPERIMENTAL_VOICE_CONTROLS_2 = {"speed": 0.4, "emotion": []}
 
-SAMPLE_VOICE_NAME = "Southern Woman"
 SAMPLE_VOICE_ID = "f9836c6e-a0bd-460e-9d3c-f7299fa60f94"
 SAMPLE_VOICE_SPEC = TtsRequestIdSpecifierParams(mode="id", id=SAMPLE_VOICE_ID)
 SAMPLE_TRANSCRIPT = "Hello, world! I'm generating audio on Cartesia."
@@ -224,7 +223,6 @@ def test_get_voice_from_id(client: Cartesia):
     logger.info("Testing voices.get")
     voice = client.voices.get(SAMPLE_VOICE_ID)
     assert voice.id == SAMPLE_VOICE_ID
-    assert voice.name == SAMPLE_VOICE_NAME
     assert voice.is_owner is False
 
     # The API does not yet support expand[]=tags for voices.list, but voices.get does return tags.
@@ -237,13 +235,11 @@ def test_get_voice_from_id(client: Cartesia):
     # Search for the voice in the list with a reasonable limit to avoid full pagination
     # If not found in first batch, the voice might be further down or the test voice
     # might need to be updated to use a more stable voice ID
-    voice_ids = []
     count = 0
     voice_found = False
     max_voices_to_check = 200 
     
     for v in voices:
-        voice_ids.append(v.id)
         if v.id == voice.id:
             voice_found = True
             break
@@ -254,11 +250,6 @@ def test_get_voice_from_id(client: Cartesia):
     if not voice_found:
         logger.warning(f"Voice {SAMPLE_VOICE_ID} not found in first {max_voices_to_check} voices from list(). "
                       f"This might indicate the voice has moved in the pagination or the test needs updating.")
-        assert voice.id == SAMPLE_VOICE_ID
-        assert voice.name == SAMPLE_VOICE_NAME
-    else:
-        # Voice was found in the list, so the assertion should pass
-        assert voice.id in voice_ids
 
 
 @pytest.mark.parametrize("mode", ["similarity", "stability"])


### PR DESCRIPTION
Changes:
- When closing `AsyncTtsWebsocket`, set `_closing` to `True` while `close` is called
- In `_process_responses`, ignore errors raised when reading from the websocket that are because the websocket is closed/closing if `_closing` is `True`
- Minor: removes unused `_error` fields
- Minor: updates unit test to be less strict for voice names