### PR TITLE
Fixes AttributeError thrown on unexpected close

### DIFF
--- a/src/cartesia/tts/_async_websocket.py
+++ b/src/cartesia/tts/_async_websocket.py
@@ -291,6 +291,7 @@ class AsyncTtsWebsocket(TtsWebsocket):
         self.websocket = None
         self._context_queues: Dict[str, List[asyncio.Queue]] = {}
         self._processing_task: Optional[asyncio.Task] = None
+        self._closing = False
 
     def __del__(self):
         try:


### PR DESCRIPTION
Ensures `_closing` is always initialized.