### PR TITLE
fix: correctly route events to concurrent contexts

### DIFF
--- a/src/cartesia/resources/tts.py
+++ b/src/cartesia/resources/tts.py
@@ -46,7 +46,7 @@ from ..types.model_speed import ModelSpeed
 from ..types.supported_language import SupportedLanguage
 from ..types.websocket_response import WebsocketResponse
 from ..types.voice_specifier_param import VoiceSpecifierParam
-from ..types.websocket_client_event import GenerationRequest, WebsocketClientEvent
+from ..types.websocket_client_event import GenerationRequest, CancelContextRequest, WebsocketClientEvent
 from ..types.generation_config_param import GenerationConfigParam
 from ..types.websocket_client_event_param import WebsocketClientEventParam
 from ..types.websocket_connection_options import WebsocketConnectionOptions
@@ -923,9 +923,10 @@ class AsyncTTSResourceConnection:
 
     _connection: AsyncWebsocketConnection
 
-    def __init__(self, connection: AsyncWebsocketConnection) -> None:
+    def __init__(self, connection: AsyncWebsocketConnection, manager: AsyncTTSResourceConnectionManager | None = None) -> None:
         import asyncio as _asyncio
         self._connection = connection
+        self._manager = manager
         self._context_queues: dict[str, asyncio.Queue[WebsocketResponse]] = {}
         self._recv_lock: asyncio.Lock = _asyncio.Lock()
 
@@ -950,7 +951,7 @@ class AsyncTTSResourceConnection:
         """
         return self.parse_event(await self.recv_bytes())
 
-    async def recv_bytes(self) -> bytes:
+    async def recv_bytes(self, timeout: float | None = None) -> bytes:
         """Receive the next message from the connection as raw bytes.
 
         Canceling this method is safe. There's no risk of losing data.
@@ -958,11 +959,16 @@ class AsyncTTSResourceConnection:
         If you want to parse the message into a `WebsocketResponse` object like `.recv()` does,
         then you can call `.parse_event(data)`.
         """
-        message = await self._connection.recv(decode=False)
+        if timeout is not None:
+            import asyncio as _asyncio
+            message = await _asyncio.wait_for(self._connection.recv(decode=False), timeout=timeout)
+        else:
+            message = await self._connection.recv(decode=False)
         log.debug(f"Received websocket message: %s", message)
         return message
 
     async def send(self, event: WebsocketClientEvent | WebsocketClientEventParam) -> None:
+        await self._ensure_connected()
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
@@ -972,6 +978,15 @@ class AsyncTTSResourceConnection:
 
     async def close(self, *, code: int = 1000, reason: str = "") -> None:
         await self._connection.close(code=code, reason=reason)
+
+    async def _ensure_connected(self) -> None:
+        from websockets.protocol import State
+
+        if self._manager is not None and self._connection.state in (State.CLOSED, State.CLOSING):
+            log.debug("Connection is not open (state=%s), reconnecting...", self._connection.state)
+            new_conn = await self._manager.__aenter__()
+            self._connection = new_conn._connection
+            self._context_queues.clear()
 
     def parse_event(self, data: str | bytes) -> WebsocketResponse:
         """
@@ -987,6 +1002,7 @@ class AsyncTTSResourceConnection:
         self,
         context_id: Optional[str] = None,
         *,
+        timeout: float | None = None,
         model_id: str | None = None,
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
@@ -1016,6 +1032,7 @@ class AsyncTTSResourceConnection:
         return AsyncWebSocketContext(
             self,
             context_id,
+            timeout=timeout,
             model_id=model_id,
             voice=voice,
             output_format=output_format,
@@ -1098,7 +1115,8 @@ class AsyncTTSResourceConnectionManager:
                     self.__extra_headers,
                 ),
                 **self.__websocket_connection_options,
-            )
+            ),
+            manager=self,
         )
 
         return self.__connection
@@ -1126,8 +1144,9 @@ class TTSResourceConnection:
 
     _connection: WebsocketConnection
 
-    def __init__(self, connection: WebsocketConnection) -> None:
+    def __init__(self, connection: WebsocketConnection, manager: TTSResourceConnectionManager | None = None) -> None:
         self._connection = connection
+        self._manager = manager
         self._context_queues: dict[str, queue.Queue[WebsocketResponse]] = {}
 
     def __iter__(self) -> Iterator[WebsocketResponse]:
@@ -1151,7 +1170,7 @@ class TTSResourceConnection:
         """
         return self.parse_event(self.recv_bytes())
 
-    def recv_bytes(self) -> bytes:
+    def recv_bytes(self, timeout: float | None = None) -> bytes:
         """Receive the next message from the connection as raw bytes.
 
         Canceling this method is safe. There's no risk of losing data.
@@ -1159,11 +1178,12 @@ class TTSResourceConnection:
         If you want to parse the message into a `WebsocketResponse` object like `.recv()` does,
         then you can call `.parse_event(data)`.
         """
-        message = self._connection.recv(decode=False)
+        message = self._connection.recv(decode=False, timeout=timeout)
         log.debug(f"Received websocket message: %s", message)
         return message
 
     def send(self, event: WebsocketClientEvent | WebsocketClientEventParam) -> None:
+        self._ensure_connected()
         data = (
             event.to_json(use_api_names=True, exclude_defaults=True, exclude_unset=True)
             if isinstance(event, BaseModel)
@@ -1173,6 +1193,15 @@ class TTSResourceConnection:
 
     def close(self, *, code: int = 1000, reason: str = "") -> None:
         self._connection.close(code=code, reason=reason)
+
+    def _ensure_connected(self) -> None:
+        from websockets.protocol import State
+
+        if self._manager is not None and self._connection.state in (State.CLOSED, State.CLOSING):
+            log.debug("Connection is not open (state=%s), reconnecting...", self._connection.state)
+            new_conn = self._manager.__enter__()
+            self._connection = new_conn._connection
+            self._context_queues.clear()
 
     def parse_event(self, data: str | bytes) -> WebsocketResponse:
         """
@@ -1188,6 +1217,7 @@ class TTSResourceConnection:
         self,
         context_id: Optional[str] = None,
         *,
+        timeout: float | None = None,
         model_id: str | None = None,
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
@@ -1216,6 +1246,7 @@ class TTSResourceConnection:
         return WebSocketContext(
             self,
             context_id,
+            timeout=timeout,
             model_id=model_id,
             voice=voice,
             output_format=output_format,
@@ -1298,7 +1329,8 @@ class TTSResourceConnectionManager:
                     self.__extra_headers,
                 ),
                 **self.__websocket_connection_options,
-            )
+            ),
+            manager=self,
         )
 
         return self.__connection
@@ -1329,6 +1361,7 @@ class WebSocketContext:
         connection: 'TTSResourceConnection',
         context_id: str,
         *,
+        timeout: float | None = None,
         model_id: str | None = None,
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
@@ -1338,6 +1371,7 @@ class WebSocketContext:
         self._connection = connection
         self._context_id = context_id
         self._completed = False
+        self._timeout = timeout
         self._model_id = model_id
         self._voice = voice
         self._output_format = output_format
@@ -1458,6 +1492,11 @@ class WebSocketContext:
         )
         self._completed = True
 
+    def cancel(self) -> None:
+        """Cancel this context, stopping any in-progress generation."""
+        self._connection.send(CancelContextRequest(cancel=True, context_id=self._context_id))
+        self._connection._context_queues.pop(self._context_id, None)
+
     def receive(self) -> Iterator[WebsocketResponse]:
         """Receive responses filtered to this context only.
 
@@ -1468,6 +1507,7 @@ class WebSocketContext:
         from websockets.exceptions import ConnectionClosedOK
 
         my_queue = self._connection._context_queues.get(self._context_id)
+        done = False
 
         try:
             while True:
@@ -1476,7 +1516,8 @@ class WebSocketContext:
                     try:
                         event = my_queue.get_nowait()
                         yield event
-                        if event.type == "done":
+                        if event.type in ("done", "error"):
+                            done = True
                             return
                         continue
                     except queue.Empty:
@@ -1484,8 +1525,10 @@ class WebSocketContext:
 
                 # 2. Read the next event from the connection.
                 try:
-                    event = self._connection.recv()
+                    raw = self._connection.recv_bytes(timeout=self._timeout)
+                    event = self._connection.parse_event(raw)
                 except ConnectionClosedOK:
+                    done = True
                     return
 
                 # 3. Route the event.
@@ -1493,7 +1536,8 @@ class WebSocketContext:
 
                 if event_ctx == self._context_id:
                     yield event
-                    if event.type == "done":
+                    if event.type in ("done", "error"):
+                        done = True
                         return
                 elif event_ctx is not None and event_ctx in self._connection._context_queues:
                     self._connection._context_queues[event_ctx].put(event)
@@ -1501,14 +1545,21 @@ class WebSocketContext:
                     # Global events without context_id
                     yield event
                     if event.type in ("done", "error"):
+                        done = True
                         return
                 else:
                     # Unregistered context — yield for backwards compat
                     yield event
                     if event.type == "done":
+                        done = True
                         return
         finally:
-            self._connection._context_queues.pop(self._context_id, None)
+            # Only unregister the queue if the context completed.  If the
+            # consumer exited early (break / cancel), keep the queue so
+            # future events for this context_id are absorbed rather than
+            # leaking into other contexts via the fallback path.
+            if done:
+                self._connection._context_queues.pop(self._context_id, None)
 
 
 class AsyncWebSocketContext:
@@ -1519,6 +1570,7 @@ class AsyncWebSocketContext:
         connection: 'AsyncTTSResourceConnection',
         context_id: str,
         *,
+        timeout: float | None = None,
         model_id: str | None = None,
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
@@ -1528,6 +1580,7 @@ class AsyncWebSocketContext:
         self._connection = connection
         self._context_id = context_id
         self._completed = False
+        self._timeout = timeout
         self._model_id = model_id
         self._voice = voice
         self._output_format = output_format
@@ -1648,6 +1701,11 @@ class AsyncWebSocketContext:
         )
         self._completed = True
 
+    async def cancel(self) -> None:
+        """Cancel this context, stopping any in-progress generation."""
+        await self._connection.send(CancelContextRequest(cancel=True, context_id=self._context_id))
+        self._connection._context_queues.pop(self._context_id, None)
+
     async def receive(self) -> AsyncIterator[WebsocketResponse]:
         """Receive responses filtered to this context only.
 
@@ -1662,6 +1720,7 @@ class AsyncWebSocketContext:
         from websockets.exceptions import ConnectionClosedOK
 
         my_queue = self._connection._context_queues.get(self._context_id)
+        done = False
 
         try:
             while True:
@@ -1670,7 +1729,8 @@ class AsyncWebSocketContext:
                     try:
                         event = my_queue.get_nowait()
                         yield event
-                        if event.type == "done":
+                        if event.type in ("done", "error"):
+                            done = True
                             return
                         continue
                     except (_asyncio.QueueEmpty, queue.Empty):
@@ -1692,9 +1752,14 @@ class AsyncWebSocketContext:
                     if to_yield is None:
                         # Read the next event from the wire.
                         try:
-                            event = await self._connection.recv()
+                            raw = await self._connection.recv_bytes(timeout=self._timeout)
+                            event = self._connection.parse_event(raw)
                         except ConnectionClosedOK:
+                            done = True
                             return
+                        except TimeoutError:
+                            done = True
+                            raise
 
                         # Route the event.
                         event_ctx = event.context_id if hasattr(event, "context_id") else None
@@ -1712,12 +1777,16 @@ class AsyncWebSocketContext:
                 # Lock released — now yield outside the critical section.
                 if to_yield is not None:
                     yield to_yield
-                    if to_yield.type == "done":
-                        return
-                    if to_yield.type == "error" and not hasattr(to_yield, "context_id"):
+                    if to_yield.type in ("done", "error"):
+                        done = True
                         return
         finally:
-            self._connection._context_queues.pop(self._context_id, None)
+            # Only unregister the queue if the context completed.  If the
+            # consumer exited early (break / cancel), keep the queue so
+            # future events for this context_id are absorbed rather than
+            # leaking into other contexts via the fallback path.
+            if done:
+                self._connection._context_queues.pop(self._context_id, None)
 
 
 class BackcompatWebSocketTtsOutput(BaseModel):
@@ -1763,11 +1832,17 @@ class BackcompatTTSResourceConnection:
         context_id: Optional[str] = None,
         stream: bool = True,
         **kwargs: Any,
-    ) -> Iterator[BackcompatWebSocketTtsOutput]:
-        """Send a request and yield responses (v2 compatible)."""
+    ) -> "Iterator[BackcompatWebSocketTtsOutput] | BackcompatWebSocketTtsOutput":
+        """Send a request and return responses (v2 compatible).
+
+        If stream is True, returns an iterator of BackcompatWebSocketTtsOutput chunks.
+        If stream is False, returns a single BackcompatWebSocketTtsOutput with all
+        audio concatenated and timestamps aggregated (matching v2 behaviour).
+        """
         if not self._connection:
             self.connect()
         assert self._connection is not None
+        self._connection._ensure_connected()
 
         ctx = self._connection.context(context_id)
 
@@ -1784,6 +1859,9 @@ class BackcompatTTSResourceConnection:
         # Generate output stream
         def generator() -> Iterator[BackcompatWebSocketTtsOutput]:
             for event in ctx.receive():
+                if event.type == "error":
+                    raise RuntimeError(f"Error generating audio:\n{getattr(event, 'error', 'Unknown error')}")
+
                 out = BackcompatWebSocketTtsOutput(
                     context_id=event.context_id
                 )
@@ -1802,8 +1880,33 @@ class BackcompatTTSResourceConnection:
 
         if stream:
             return generator()
-        else:
-            return iter(list(generator()))
+
+        audio_parts: list[bytes] = []
+        words: list[str] = []
+        word_starts: list[float] = []
+        word_ends: list[float] = []
+        phonemes: list[str] = []
+        phoneme_starts: list[float] = []
+        phoneme_ends: list[float] = []
+        for chunk in generator():
+            if chunk.audio is not None:
+                audio_parts.append(chunk.audio)
+            if chunk.word_timestamps is not None:
+                wt = chunk.word_timestamps
+                words.extend(wt.words)
+                word_starts.extend(wt.start)
+                word_ends.extend(wt.end)
+            if chunk.phoneme_timestamps is not None:
+                pt = chunk.phoneme_timestamps
+                phonemes.extend(pt.phonemes)
+                phoneme_starts.extend(pt.start)
+                phoneme_ends.extend(pt.end)
+        return BackcompatWebSocketTtsOutput(
+            audio=b"".join(audio_parts) if audio_parts else None,
+            context_id=context_id,
+            word_timestamps={"words": words, "start": word_starts, "end": word_ends} if words else None,
+            phoneme_timestamps={"phonemes": phonemes, "start": phoneme_starts, "end": phoneme_ends} if phonemes else None,
+        )
 
 
 class AsyncBackcompatTTSResourceConnection:
@@ -1838,11 +1941,17 @@ class AsyncBackcompatTTSResourceConnection:
         context_id: Optional[str] = None,
         stream: bool = True,
         **kwargs: Any,
-    ) -> AsyncIterator[BackcompatWebSocketTtsOutput]:
-        """Send a request and yield responses (v2 compatible)."""
+    ) -> "AsyncIterator[BackcompatWebSocketTtsOutput] | BackcompatWebSocketTtsOutput":
+        """Send a request and return responses (v2 compatible).
+
+        If stream is True, returns an async iterator of BackcompatWebSocketTtsOutput chunks.
+        If stream is False, returns a single BackcompatWebSocketTtsOutput with all
+        audio concatenated and timestamps aggregated (matching v2 behaviour).
+        """
         if not self._connection:
             await self.connect()
         assert self._connection is not None
+        await self._connection._ensure_connected()
 
         ctx = self._connection.context(context_id)
 
@@ -1859,6 +1968,9 @@ class AsyncBackcompatTTSResourceConnection:
         # Generate output stream
         async def generator() -> AsyncIterator[BackcompatWebSocketTtsOutput]:
             async for event in ctx.receive():
+                if event.type == "error":
+                    raise RuntimeError(f"Error generating audio:\n{getattr(event, 'error', 'Unknown error')}")
+
                 out = BackcompatWebSocketTtsOutput(
                     context_id=event.context_id
                 )
@@ -1877,16 +1989,30 @@ class AsyncBackcompatTTSResourceConnection:
 
         if stream:
             return generator()
-        else:
-            results: list[BackcompatWebSocketTtsOutput] = []
-            async for item in generator():
-                results.append(item)
 
-            async def async_iter() -> AsyncIterator[BackcompatWebSocketTtsOutput]:
-                for item in results:
-                    yield item
-
-            return async_iter()
-
-
-# Custom Cartesia stuff:
+        audio_parts: list[bytes] = []
+        words: list[str] = []
+        word_starts: list[float] = []
+        word_ends: list[float] = []
+        phonemes: list[str] = []
+        phoneme_starts: list[float] = []
+        phoneme_ends: list[float] = []
+        async for chunk in generator():
+            if chunk.audio is not None:
+                audio_parts.append(chunk.audio)
+            if chunk.word_timestamps is not None:
+                wt = chunk.word_timestamps
+                words.extend(wt.words)
+                word_starts.extend(wt.start)
+                word_ends.extend(wt.end)
+            if chunk.phoneme_timestamps is not None:
+                pt = chunk.phoneme_timestamps
+                phonemes.extend(pt.phonemes)
+                phoneme_starts.extend(pt.start)
+                phoneme_ends.extend(pt.end)
+        return BackcompatWebSocketTtsOutput(
+            audio=b"".join(audio_parts) if audio_parts else None,
+            context_id=context_id,
+            word_timestamps={"words": words, "start": word_starts, "end": word_ends} if words else None,
+            phoneme_timestamps={"phonemes": phonemes, "start": phoneme_starts, "end": phoneme_ends} if phonemes else None,
+        )

--- a/src/cartesia/resources/tts.py
+++ b/src/cartesia/resources/tts.py
@@ -924,11 +924,11 @@ class AsyncTTSResourceConnection:
     _connection: AsyncWebsocketConnection
 
     def __init__(self, connection: AsyncWebsocketConnection, manager: AsyncTTSResourceConnectionManager | None = None) -> None:
-        import asyncio as _asyncio
         self._connection = connection
         self._manager = manager
         self._context_queues: dict[str, asyncio.Queue[WebsocketResponse]] = {}
-        self._recv_lock: asyncio.Lock = _asyncio.Lock()
+        self._processing_task: asyncio.Task[None] | None = None
+        self._closing = False
 
     async def __aiter__(self) -> AsyncIterator[WebsocketResponse]:
         """
@@ -975,15 +975,61 @@ class AsyncTTSResourceConnection:
             else json.dumps(await async_maybe_transform(event, WebsocketClientEventParam))
         )
         await self._connection.send(data)
+        self._dispatch_listener()
 
     async def close(self, *, code: int = 1000, reason: str = "") -> None:
-        await self._connection.close(code=code, reason=reason)
+        import asyncio as _asyncio
+
+        self._closing = True
+        try:
+            if self._processing_task is not None:
+                self._processing_task.cancel()
+                try:
+                    await self._processing_task
+                except _asyncio.CancelledError:
+                    pass
+                self._processing_task = None
+            await self._connection.close(code=code, reason=reason)
+        finally:
+            self._closing = False
+
+    def _dispatch_listener(self) -> None:
+        import asyncio as _asyncio
+
+        if self._processing_task is None or self._processing_task.done():
+            self._processing_task = _asyncio.create_task(self._process_responses())
+
+    async def _process_responses(self) -> None:
+        from websockets.exceptions import ConnectionClosed
+
+        try:
+            while True:
+                raw = await self._connection.recv(decode=False)
+                log.debug("Received websocket message: %s", raw)
+                event = self.parse_event(raw)
+                event_ctx = event.context_id if hasattr(event, "context_id") else None
+                if event_ctx is not None and event_ctx in self._context_queues:
+                    await self._context_queues[event_ctx].put(event)
+                else:
+                    log.debug("Received event for unregistered context %s", event_ctx)
+        except ConnectionClosed:
+            if not self._closing:
+                log.warning("WebSocket connection closed unexpectedly")
 
     async def _ensure_connected(self) -> None:
+        import asyncio as _asyncio
+
         from websockets.protocol import State
 
         if self._manager is not None and self._connection.state in (State.CLOSED, State.CLOSING):
             log.debug("Connection is not open (state=%s), reconnecting...", self._connection.state)
+            if self._processing_task is not None:
+                self._processing_task.cancel()
+                try:
+                    await self._processing_task
+                except _asyncio.CancelledError:
+                    pass
+                self._processing_task = None
             new_conn = await self._manager.__aenter__()
             self._connection = new_conn._connection
             self._context_queues.clear()
@@ -1007,6 +1053,10 @@ class AsyncTTSResourceConnection:
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
         language: SupportedLanguage | None = None,
+        duration: float | None = None,
+        speed: ModelSpeed | None = None,
+        add_timestamps: bool | None = None,
+        add_phoneme_timestamps: bool | None = None,
         generation_config: GenerationConfigParam | None = None,
     ) -> AsyncWebSocketContext:
         """Create a context helper for managing conversational flows.
@@ -1018,6 +1068,10 @@ class AsyncTTSResourceConnection:
             voice: Default voice for push().
             output_format: Default output_format for push().
             language: Default language for push().
+            duration: Default duration for push().
+            speed: Default speed for push().
+            add_timestamps: Default add_timestamps for push().
+            add_phoneme_timestamps: Default add_phoneme_timestamps for push().
             generation_config: Default generation_config for push().
 
         Returns:
@@ -1037,6 +1091,10 @@ class AsyncTTSResourceConnection:
             voice=voice,
             output_format=output_format,
             language=language,
+            duration=duration,
+            speed=speed,
+            add_timestamps=add_timestamps,
+            add_phoneme_timestamps=add_phoneme_timestamps,
             generation_config=generation_config,
         )
 
@@ -1222,6 +1280,10 @@ class TTSResourceConnection:
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
         language: SupportedLanguage | None = None,
+        duration: float | None = None,
+        speed: ModelSpeed | None = None,
+        add_timestamps: bool | None = None,
+        add_phoneme_timestamps: bool | None = None,
         generation_config: GenerationConfigParam | None = None,
     ) -> WebSocketContext:
         """Create a context helper for managing conversational flows.
@@ -1233,6 +1295,10 @@ class TTSResourceConnection:
             voice: Default voice for push().
             output_format: Default output_format for push().
             language: Default language for push().
+            duration: Default duration for push().
+            speed: Default speed for push().
+            add_timestamps: Default add_timestamps for push().
+            add_phoneme_timestamps: Default add_phoneme_timestamps for push().
             generation_config: Default generation_config for push().
 
         Returns:
@@ -1251,6 +1317,10 @@ class TTSResourceConnection:
             voice=voice,
             output_format=output_format,
             language=language,
+            duration=duration,
+            speed=speed,
+            add_timestamps=add_timestamps,
+            add_phoneme_timestamps=add_phoneme_timestamps,
             generation_config=generation_config,
         )
 
@@ -1366,6 +1436,10 @@ class WebSocketContext:
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
         language: SupportedLanguage | None = None,
+        duration: float | None = None,
+        speed: ModelSpeed | None = None,
+        add_timestamps: bool | None = None,
+        add_phoneme_timestamps: bool | None = None,
         generation_config: GenerationConfigParam | None = None,
     ):
         self._connection = connection
@@ -1376,6 +1450,10 @@ class WebSocketContext:
         self._voice = voice
         self._output_format = output_format
         self._language = language
+        self._duration = duration
+        self._speed = speed
+        self._add_timestamps = add_timestamps
+        self._add_phoneme_timestamps = add_phoneme_timestamps
         self._generation_config = generation_config
 
     def send(
@@ -1451,6 +1529,10 @@ class WebSocketContext:
             raise ValueError("Context was initialized without required parameters (model_id, voice). Cannot use push().")
 
         language: SupportedLanguage | Omit = cast(SupportedLanguage, self._language) if self._language is not None else omit
+        duration: float | Omit = self._duration if self._duration is not None else omit
+        speed: ModelSpeed | Omit = self._speed if self._speed is not None else omit
+        add_timestamps: bool | Omit = self._add_timestamps if self._add_timestamps is not None else omit
+        add_phoneme_timestamps: bool | Omit = self._add_phoneme_timestamps if self._add_phoneme_timestamps is not None else omit
 
         # Use passed generation_config if provided in kwargs, otherwise use context default
         generation_config: GenerationConfigParam | None = kwargs.pop("generation_config", self._generation_config)
@@ -1462,6 +1544,10 @@ class WebSocketContext:
             output_format=self._output_format,
             continue_=True,
             language=language,
+            duration=duration,
+            speed=speed,
+            add_timestamps=add_timestamps,
+            add_phoneme_timestamps=add_phoneme_timestamps,
             flush=flush,
             generation_config=generation_config,
             **kwargs,
@@ -1530,6 +1616,9 @@ class WebSocketContext:
                 except ConnectionClosedOK:
                     done = True
                     return
+                except TimeoutError:
+                    done = True
+                    raise
 
                 # 3. Route the event.
                 event_ctx = event.context_id if hasattr(event, "context_id") else None
@@ -1575,6 +1664,10 @@ class AsyncWebSocketContext:
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
         language: SupportedLanguage | None = None,
+        duration: float | None = None,
+        speed: ModelSpeed | None = None,
+        add_timestamps: bool | None = None,
+        add_phoneme_timestamps: bool | None = None,
         generation_config: GenerationConfigParam | None = None,
     ):
         self._connection = connection
@@ -1585,6 +1678,10 @@ class AsyncWebSocketContext:
         self._voice = voice
         self._output_format = output_format
         self._language = language
+        self._duration = duration
+        self._speed = speed
+        self._add_timestamps = add_timestamps
+        self._add_phoneme_timestamps = add_phoneme_timestamps
         self._generation_config = generation_config
 
     async def send(
@@ -1660,6 +1757,10 @@ class AsyncWebSocketContext:
             raise ValueError("Context was initialized without required parameters (model_id, voice). Cannot use push().")
 
         language: SupportedLanguage | Omit = cast(SupportedLanguage, self._language) if self._language is not None else omit
+        duration: float | Omit = self._duration if self._duration is not None else omit
+        speed: ModelSpeed | Omit = self._speed if self._speed is not None else omit
+        add_timestamps: bool | Omit = self._add_timestamps if self._add_timestamps is not None else omit
+        add_phoneme_timestamps: bool | Omit = self._add_phoneme_timestamps if self._add_phoneme_timestamps is not None else omit
 
         # Use passed generation_config if provided in kwargs, otherwise use context default
         generation_config: GenerationConfigParam | None = kwargs.pop("generation_config", self._generation_config)
@@ -1671,6 +1772,10 @@ class AsyncWebSocketContext:
             output_format=self._output_format,
             continue_=True,
             language=language,
+            duration=duration,
+            speed=speed,
+            add_timestamps=add_timestamps,
+            add_phoneme_timestamps=add_phoneme_timestamps,
             flush=flush,
             generation_config=generation_config,
             **kwargs,
@@ -1709,82 +1814,34 @@ class AsyncWebSocketContext:
     async def receive(self) -> AsyncIterator[WebsocketResponse]:
         """Receive responses filtered to this context only.
 
-        When multiple contexts share a connection, the context that reads from
-        the wire acts as a router: non-matching events are placed onto the
-        correct context's queue so they are never lost.  A lock ensures only
-        one context reads from the wire at a time; the others wait on their
-        queues.
+        A background task on the connection continuously reads from the wire
+        and routes events into per-context queues.  This method simply drains
+        the queue for this context.
         """
         import asyncio as _asyncio
 
-        from websockets.exceptions import ConnectionClosedOK
-
         my_queue = self._connection._context_queues.get(self._context_id)
+        if my_queue is None:
+            return
+
         done = False
 
         try:
             while True:
-                # 1. Drain our own queue first (events routed here by another context).
-                if my_queue is not None:
-                    try:
-                        event = my_queue.get_nowait()
-                        yield event
-                        if event.type in ("done", "error"):
-                            done = True
-                            return
-                        continue
-                    except (_asyncio.QueueEmpty, queue.Empty):
-                        pass
+                try:
+                    if self._timeout is not None:
+                        event = await _asyncio.wait_for(my_queue.get(), timeout=self._timeout)
+                    else:
+                        event = await my_queue.get()
+                except TimeoutError:
+                    done = True
+                    raise
 
-                # 2. Acquire the recv lock so only one context reads the wire.
-                #    We must release the lock *before* yielding so other contexts
-                #    aren't blocked while the caller processes the event.
-                to_yield: WebsocketResponse | None = None
-
-                async with self._connection._recv_lock:
-                    # Re-check queue — events may have arrived while we waited.
-                    if my_queue is not None:
-                        try:
-                            to_yield = my_queue.get_nowait()
-                        except (_asyncio.QueueEmpty, queue.Empty):
-                            pass
-
-                    if to_yield is None:
-                        # Read the next event from the wire.
-                        try:
-                            raw = await self._connection.recv_bytes(timeout=self._timeout)
-                            event = self._connection.parse_event(raw)
-                        except ConnectionClosedOK:
-                            done = True
-                            return
-                        except TimeoutError:
-                            done = True
-                            raise
-
-                        # Route the event.
-                        event_ctx = event.context_id if hasattr(event, "context_id") else None
-
-                        if event_ctx == self._context_id:
-                            to_yield = event
-                        elif event_ctx is not None and event_ctx in self._connection._context_queues:
-                            await self._connection._context_queues[event_ctx].put(event)
-                        elif not hasattr(event, "context_id") and event.type in ("done", "error"):
-                            to_yield = event
-                        else:
-                            # Unregistered context — yield for backwards compat
-                            to_yield = event
-
-                # Lock released — now yield outside the critical section.
-                if to_yield is not None:
-                    yield to_yield
-                    if to_yield.type in ("done", "error"):
-                        done = True
-                        return
+                yield event
+                if event.type in ("done", "error"):
+                    done = True
+                    return
         finally:
-            # Only unregister the queue if the context completed.  If the
-            # consumer exited early (break / cancel), keep the queue so
-            # future events for this context_id are absorbed rather than
-            # leaking into other contexts via the fallback path.
             if done:
                 self._connection._context_queues.pop(self._context_id, None)
 

--- a/src/cartesia/resources/tts.py
+++ b/src/cartesia/resources/tts.py
@@ -975,7 +975,6 @@ class AsyncTTSResourceConnection:
             else json.dumps(await async_maybe_transform(event, WebsocketClientEventParam))
         )
         await self._connection.send(data)
-        self._dispatch_listener()
 
     async def close(self, *, code: int = 1000, reason: str = "") -> None:
         import asyncio as _asyncio
@@ -1744,6 +1743,7 @@ class AsyncWebSocketContext:
 
         request = GenerationRequest(**request_params)
         await self._connection.send(request)
+        self._connection._dispatch_listener()
 
     async def push(
         self,

--- a/src/cartesia/resources/tts.py
+++ b/src/cartesia/resources/tts.py
@@ -1052,8 +1052,6 @@ class AsyncTTSResourceConnection:
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
         language: SupportedLanguage | None = None,
-        duration: float | None = None,
-        speed: ModelSpeed | None = None,
         add_timestamps: bool | None = None,
         add_phoneme_timestamps: bool | None = None,
         generation_config: GenerationConfigParam | None = None,
@@ -1067,8 +1065,6 @@ class AsyncTTSResourceConnection:
             voice: Default voice for push().
             output_format: Default output_format for push().
             language: Default language for push().
-            duration: Default duration for push().
-            speed: Default speed for push().
             add_timestamps: Default add_timestamps for push().
             add_phoneme_timestamps: Default add_phoneme_timestamps for push().
             generation_config: Default generation_config for push().
@@ -1090,8 +1086,6 @@ class AsyncTTSResourceConnection:
             voice=voice,
             output_format=output_format,
             language=language,
-            duration=duration,
-            speed=speed,
             add_timestamps=add_timestamps,
             add_phoneme_timestamps=add_phoneme_timestamps,
             generation_config=generation_config,
@@ -1279,8 +1273,6 @@ class TTSResourceConnection:
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
         language: SupportedLanguage | None = None,
-        duration: float | None = None,
-        speed: ModelSpeed | None = None,
         add_timestamps: bool | None = None,
         add_phoneme_timestamps: bool | None = None,
         generation_config: GenerationConfigParam | None = None,
@@ -1294,8 +1286,6 @@ class TTSResourceConnection:
             voice: Default voice for push().
             output_format: Default output_format for push().
             language: Default language for push().
-            duration: Default duration for push().
-            speed: Default speed for push().
             add_timestamps: Default add_timestamps for push().
             add_phoneme_timestamps: Default add_phoneme_timestamps for push().
             generation_config: Default generation_config for push().
@@ -1316,8 +1306,6 @@ class TTSResourceConnection:
             voice=voice,
             output_format=output_format,
             language=language,
-            duration=duration,
-            speed=speed,
             add_timestamps=add_timestamps,
             add_phoneme_timestamps=add_phoneme_timestamps,
             generation_config=generation_config,
@@ -1435,8 +1423,6 @@ class WebSocketContext:
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
         language: SupportedLanguage | None = None,
-        duration: float | None = None,
-        speed: ModelSpeed | None = None,
         add_timestamps: bool | None = None,
         add_phoneme_timestamps: bool | None = None,
         generation_config: GenerationConfigParam | None = None,
@@ -1449,8 +1435,6 @@ class WebSocketContext:
         self._voice = voice
         self._output_format = output_format
         self._language = language
-        self._duration = duration
-        self._speed = speed
         self._add_timestamps = add_timestamps
         self._add_phoneme_timestamps = add_phoneme_timestamps
         self._generation_config = generation_config
@@ -1528,8 +1512,6 @@ class WebSocketContext:
             raise ValueError("Context was initialized without required parameters (model_id, voice). Cannot use push().")
 
         language: SupportedLanguage | Omit = cast(SupportedLanguage, self._language) if self._language is not None else omit
-        duration: float | Omit = self._duration if self._duration is not None else omit
-        speed: ModelSpeed | Omit = self._speed if self._speed is not None else omit
         add_timestamps: bool | Omit = self._add_timestamps if self._add_timestamps is not None else omit
         add_phoneme_timestamps: bool | Omit = self._add_phoneme_timestamps if self._add_phoneme_timestamps is not None else omit
 
@@ -1543,8 +1525,6 @@ class WebSocketContext:
             output_format=self._output_format,
             continue_=True,
             language=language,
-            duration=duration,
-            speed=speed,
             add_timestamps=add_timestamps,
             add_phoneme_timestamps=add_phoneme_timestamps,
             flush=flush,
@@ -1663,8 +1643,6 @@ class AsyncWebSocketContext:
         voice: VoiceSpecifierParam | None = None,
         output_format: Dict[str, Any] | None = None,
         language: SupportedLanguage | None = None,
-        duration: float | None = None,
-        speed: ModelSpeed | None = None,
         add_timestamps: bool | None = None,
         add_phoneme_timestamps: bool | None = None,
         generation_config: GenerationConfigParam | None = None,
@@ -1677,8 +1655,6 @@ class AsyncWebSocketContext:
         self._voice = voice
         self._output_format = output_format
         self._language = language
-        self._duration = duration
-        self._speed = speed
         self._add_timestamps = add_timestamps
         self._add_phoneme_timestamps = add_phoneme_timestamps
         self._generation_config = generation_config
@@ -1757,8 +1733,6 @@ class AsyncWebSocketContext:
             raise ValueError("Context was initialized without required parameters (model_id, voice). Cannot use push().")
 
         language: SupportedLanguage | Omit = cast(SupportedLanguage, self._language) if self._language is not None else omit
-        duration: float | Omit = self._duration if self._duration is not None else omit
-        speed: ModelSpeed | Omit = self._speed if self._speed is not None else omit
         add_timestamps: bool | Omit = self._add_timestamps if self._add_timestamps is not None else omit
         add_phoneme_timestamps: bool | Omit = self._add_phoneme_timestamps if self._add_phoneme_timestamps is not None else omit
 
@@ -1772,8 +1746,6 @@ class AsyncWebSocketContext:
             output_format=self._output_format,
             continue_=True,
             language=language,
-            duration=duration,
-            speed=speed,
             add_timestamps=add_timestamps,
             add_phoneme_timestamps=add_phoneme_timestamps,
             flush=flush,

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,0 +1,226 @@
+"""Tests for the async WebSocket background dispatcher.
+
+The async connection spins up a background task that continuously reads from
+the WebSocket and routes events into per-context queues.  These unit tests
+verify two key properties using a mock WebSocket (no API key required):
+
+1. The WebSocket buffer never fills up — the background task drains it
+   even before any user code calls ``ctx.receive()``.
+2. A slow reader on one context does not block readers on other contexts.
+"""
+
+from __future__ import annotations
+
+import json
+import asyncio
+from typing import Any
+
+import pytest
+
+from cartesia.resources.tts import AsyncTTSResourceConnection
+
+# ---------------------------------------------------------------------------
+# Mock WebSocket
+# ---------------------------------------------------------------------------
+
+class MockAsyncWebsocket:
+    """Fake async WebSocket whose receive buffer is an asyncio.Queue.
+
+    Tests call ``inject_*`` helpers to push messages onto the queue.
+    The ``AsyncTTSResourceConnection`` background task calls ``recv()``
+    which pops from the same queue.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        self._closed = False
+        self._sent: list[str] = []
+
+    # -- WebSocket interface consumed by AsyncTTSResourceConnection ----------
+
+    async def recv(self, *, decode: bool = True) -> bytes | str:
+        msg = await self._queue.get()
+        if msg is None:
+            # Sentinel: simulate a clean close.
+            from websockets.exceptions import ConnectionClosedOK
+
+            raise ConnectionClosedOK(None, None)
+        return msg.decode() if decode else msg
+
+    async def send(self, data: str | bytes) -> None:
+        if isinstance(data, bytes):
+            data = data.decode()
+        self._sent.append(data)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:  # noqa: ARG002
+        self._closed = True
+
+    @property
+    def state(self) -> Any:
+        from websockets.protocol import State
+
+        return State.CLOSED if self._closed else State.OPEN
+
+    # -- Test helpers --------------------------------------------------------
+
+    def inject_chunk(self, context_id: str, seq: int = 0) -> None:
+        self._queue.put_nowait(
+            json.dumps(
+                {
+                    "type": "chunk",
+                    "context_id": context_id,
+                    "data": f"audio_{seq}",
+                    "done": False,
+                    "status_code": 200,
+                    "step_time": 0.0,
+                }
+            ).encode()
+        )
+
+    def inject_done(self, context_id: str) -> None:
+        self._queue.put_nowait(
+            json.dumps(
+                {
+                    "type": "done",
+                    "context_id": context_id,
+                    "done": True,
+                    "status_code": 200,
+                }
+            ).encode()
+        )
+
+
+def _make_connection(ws: MockAsyncWebsocket) -> AsyncTTSResourceConnection:
+    return AsyncTTSResourceConnection(ws)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_drains_websocket_buffer():
+    """The background task should consume messages even before receive() is called.
+
+    This ensures the WebSocket read buffer never fills up regardless of when
+    user code starts reading from the context queue.
+    """
+    ws = MockAsyncWebsocket()
+    conn = _make_connection(ws)
+
+    NUM_CHUNKS = 50
+    ctx_id = "buffer-test"
+
+    # Register a context (creates the queue).
+    ctx = conn.context(ctx_id)
+
+    # Push many messages onto the fake wire *before* anyone calls receive().
+    for i in range(NUM_CHUNKS):
+        ws.inject_chunk(ctx_id, seq=i)
+    ws.inject_done(ctx_id)
+
+    # Start the background dispatcher (normally triggered by send()).
+    conn._dispatch_listener()
+
+    # Wait until the mock WebSocket queue is fully drained.
+    for _ in range(200):
+        if ws._queue.empty():
+            break
+        await asyncio.sleep(0.01)
+
+    assert ws._queue.empty(), (
+        "Background task should have consumed all messages from the WebSocket"
+    )
+
+    # All messages should now be sitting in the context queue.
+    ctx_queue = conn._context_queues[ctx_id]
+    assert ctx_queue.qsize() == NUM_CHUNKS + 1  # chunks + done
+
+    # Now consume via receive() — everything should already be available.
+    chunks: list[Any] = []
+    async for event in ctx.receive():
+        if event.type == "chunk":
+            chunks.append(event)
+
+    assert len(chunks) == NUM_CHUNKS
+
+    await conn.close()
+
+
+@pytest.mark.asyncio
+async def test_slow_reader_does_not_block_fast_reader():
+    """A slow consumer on one context must not delay other contexts.
+
+    With the background dispatcher, each context reads from its own
+    independent queue.  A slow reader sleeping between iterations cannot
+    block a fast reader on a different context.
+    """
+    ws = MockAsyncWebsocket()
+    conn = _make_connection(ws)
+
+    NUM_CHUNKS = 20
+    SLOW_DELAY = 0.05  # seconds per event for slow reader
+
+    ctx_slow = conn.context("slow-ctx")
+    ctx_fast = conn.context("fast-ctx")
+
+    # Inject interleaved messages for both contexts.
+    for i in range(NUM_CHUNKS):
+        ws.inject_chunk("slow-ctx", seq=i)
+        ws.inject_chunk("fast-ctx", seq=i)
+    ws.inject_done("slow-ctx")
+    ws.inject_done("fast-ctx")
+
+    # Start dispatcher.
+    conn._dispatch_listener()
+
+    # Wait for dispatcher to drain the mock wire.
+    for _ in range(200):
+        if ws._queue.empty():
+            break
+        await asyncio.sleep(0.01)
+
+    # Slow reader: sleeps between every event.
+    async def slow_collect() -> list[Any]:
+        chunks: list[Any] = []
+        async for event in ctx_slow.receive():
+            if event.type == "chunk":
+                chunks.append(event)
+            await asyncio.sleep(SLOW_DELAY)
+        return chunks
+
+    # Fast reader: no delays.
+    fast_start: float = 0
+    fast_end: float = 0
+
+    async def fast_collect() -> list[Any]:
+        nonlocal fast_start, fast_end
+        loop = asyncio.get_event_loop()
+        fast_start = loop.time()
+        chunks: list[Any] = []
+        async for event in ctx_fast.receive():
+            if event.type == "chunk":
+                chunks.append(event)
+        fast_end = loop.time()
+        return chunks
+
+    slow_chunks, fast_chunks = await asyncio.gather(
+        slow_collect(),
+        fast_collect(),
+    )
+
+    assert len(slow_chunks) == NUM_CHUNKS
+    assert len(fast_chunks) == NUM_CHUNKS
+
+    # The fast reader should finish nearly instantly (all events already queued).
+    # The slow reader needs at least NUM_CHUNKS * SLOW_DELAY ≈ 1 second.
+    fast_duration = fast_end - fast_start
+    slow_min_duration = NUM_CHUNKS * SLOW_DELAY
+
+    assert fast_duration < slow_min_duration / 2, (
+        f"Fast reader took {fast_duration:.3f}s but slow reader needs "
+        f"~{slow_min_duration:.1f}s — fast reader should not be blocked"
+    )
+
+    await conn.close()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -855,6 +855,317 @@ def test_stt_batch_transcription(client: Cartesia, sample_audio_path: str):
 
 
 # ============================================================================
+# Context Flush Tests
+# ============================================================================
+
+
+def test_tts_websocket_context_flush_sync(client: Cartesia):
+    """Test flush on a sync WebSocket context.
+
+    Sends transcripts followed by separate flush requests (empty transcript +
+    flush=True), validates that flush_done events are received and audio is
+    produced for each segment.
+    """
+    logger.info("Testing sync context flush")
+
+    with client.tts.websocket_connect() as connection:
+        ctx = connection.context(
+            model_id=DEFAULT_MODEL_ID,
+            voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+            output_format=DEFAULT_OUTPUT_FORMAT,
+            language=SAMPLE_LANGUAGE,
+        )
+
+        transcripts = ["Hello, world!", "My name is Cartesia.", "I am a text-to-speech API."]
+        for transcript in transcripts:
+            # Send the transcript, then a separate flush request
+            ctx.push(transcript)
+            ctx.push("", flush=True)
+
+        ctx.no_more_inputs()
+
+        audio_chunks: list[bytes] = []
+        flush_count = 0
+        for response in ctx.receive():
+            if response.type == "chunk" and response.audio:
+                audio_chunks.append(response.audio)
+            elif response.type == "flush_done":
+                flush_count += 1
+
+        audio_data = b"".join(audio_chunks)
+        _validate_audio_response(audio_data, DEFAULT_OUTPUT_FORMAT)
+        assert flush_count == len(transcripts), f"Expected {len(transcripts)} flush_done events, got {flush_count}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
+async def test_tts_websocket_context_flush_async():
+    """Test flush on an async WebSocket context.
+
+    Sends transcripts followed by separate flush requests (empty transcript +
+    flush=True), validates that flush_done events are received and audio is
+    produced for each segment.
+    """
+    logger.info("Testing async context flush")
+
+    async with create_async_client() as client:
+        async with client.tts.websocket_connect() as connection:
+            ctx = connection.context(
+                model_id=DEFAULT_MODEL_ID,
+                voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+                output_format=DEFAULT_OUTPUT_FORMAT,
+                language=SAMPLE_LANGUAGE,
+            )
+
+            transcripts = ["Hello, world!", "My name is Cartesia.", "I am a text-to-speech API."]
+            for transcript in transcripts:
+                # Send the transcript, then a separate flush request
+                await ctx.push(transcript)
+                await ctx.push("", flush=True)
+
+            await ctx.no_more_inputs()
+
+            audio_chunks: list[bytes] = []
+            flush_count = 0
+            async for response in ctx.receive():
+                if response.type == "chunk" and response.audio:
+                    audio_chunks.append(response.audio)
+                elif response.type == "flush_done":
+                    flush_count += 1
+
+            audio_data = b"".join(audio_chunks)
+            _validate_audio_response(audio_data, DEFAULT_OUTPUT_FORMAT)
+            assert flush_count == len(transcripts), f"Expected {len(transcripts)} flush_done events, got {flush_count}"
+
+
+# ============================================================================
+# Context Cancel Tests
+# ============================================================================
+
+
+def test_tts_websocket_context_cancel_sync(client: Cartesia):
+    """Test cancelling a sync WebSocket context mid-generation.
+
+    Sends a long transcript, receives a few chunks, then cancels.
+    Validates that the context stops cleanly and the connection is still usable.
+    """
+    logger.info("Testing sync context cancel")
+
+    long_transcript = "This is a long sentence that should generate many audio chunks. " * 10
+
+    with client.tts.websocket_connect() as connection:
+        ctx = connection.context(
+            model_id=DEFAULT_MODEL_ID,
+            voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+            output_format=DEFAULT_OUTPUT_FORMAT,
+            language=SAMPLE_LANGUAGE,
+        )
+
+        ctx.push(long_transcript)
+        ctx.no_more_inputs()
+
+        chunks_received = 0
+        for response in ctx.receive():
+            if response.type == "chunk" and response.audio:
+                chunks_received += 1
+                if chunks_received >= 2:
+                    ctx.cancel()
+                    break
+
+        assert chunks_received >= 2, "Should have received at least 2 chunks before cancel"
+
+        # Verify the connection is still usable after cancel
+        ctx2 = connection.context(
+            model_id=DEFAULT_MODEL_ID,
+            voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+            output_format=DEFAULT_OUTPUT_FORMAT,
+            language=SAMPLE_LANGUAGE,
+        )
+        ctx2.push("Short test after cancel.")
+        ctx2.no_more_inputs()
+
+        audio_chunks: list[bytes] = []
+        for response in ctx2.receive():
+            if response.type == "chunk" and response.audio:
+                audio_chunks.append(response.audio)
+
+        audio_data = b"".join(audio_chunks)
+        _validate_audio_response(audio_data, DEFAULT_OUTPUT_FORMAT)
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
+async def test_tts_websocket_context_cancel_async():
+    """Test cancelling an async WebSocket context mid-generation.
+
+    Sends a long transcript, receives a few chunks, then cancels.
+    Validates that the context stops cleanly and the connection is still usable.
+    """
+    logger.info("Testing async context cancel")
+
+    long_transcript = "This is a long sentence that should generate many audio chunks. " * 10
+
+    async with create_async_client() as client:
+        async with client.tts.websocket_connect() as connection:
+            ctx = connection.context(
+                model_id=DEFAULT_MODEL_ID,
+                voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+                output_format=DEFAULT_OUTPUT_FORMAT,
+                language=SAMPLE_LANGUAGE,
+            )
+
+            await ctx.push(long_transcript)
+            await ctx.no_more_inputs()
+
+            chunks_received = 0
+            async for response in ctx.receive():
+                if response.type == "chunk" and response.audio:
+                    chunks_received += 1
+                    if chunks_received >= 2:
+                        await ctx.cancel()
+                        break
+
+            assert chunks_received >= 2, "Should have received at least 2 chunks before cancel"
+
+            # Verify the connection is still usable after cancel
+            ctx2 = connection.context(
+                model_id=DEFAULT_MODEL_ID,
+                voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+                output_format=DEFAULT_OUTPUT_FORMAT,
+                language=SAMPLE_LANGUAGE,
+            )
+            await ctx2.push("Short test after cancel.")
+            await ctx2.no_more_inputs()
+
+            audio_chunks: list[bytes] = []
+            async for response in ctx2.receive():
+                if response.type == "chunk" and response.audio:
+                    audio_chunks.append(response.audio)
+
+            audio_data = b"".join(audio_chunks)
+            _validate_audio_response(audio_data, DEFAULT_OUTPUT_FORMAT)
+
+
+# ============================================================================
+# Context Reuse Tests
+# ============================================================================
+
+
+def test_tts_websocket_context_reuse_sync(client: Cartesia):
+    """Test reusing a sync WebSocket context for multiple send/receive cycles.
+
+    Sends two separate rounds of transcripts on the same context (with
+    continue_=True), calls no_more_inputs once at the end, and validates that
+    audio is received for the full combined output.
+    """
+    logger.info("Testing sync context reuse")
+
+    with client.tts.websocket_connect() as connection:
+        ctx = connection.context(
+            model_id=DEFAULT_MODEL_ID,
+            voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+            output_format=DEFAULT_OUTPUT_FORMAT,
+            language=SAMPLE_LANGUAGE,
+            add_timestamps=True,
+        )
+
+        # First round of transcripts
+        transcripts_round1 = ["Hello, world!", "How are you today?"]
+        for transcript in transcripts_round1:
+            ctx.push(transcript)
+
+        # Second round of transcripts on the same context
+        transcripts_round2 = ["I am doing well.", "Thank you for asking."]
+        for transcript in transcripts_round2:
+            ctx.push(transcript)
+
+        ctx.no_more_inputs()
+
+        audio_chunks: list[bytes] = []
+        all_words: list[str] = []
+        all_starts: list[float] = []
+        all_ends: list[float] = []
+
+        for response in ctx.receive():
+            if response.type == "chunk" and response.audio:
+                audio_chunks.append(response.audio)
+            elif response.type == "timestamps":
+                wt = response.word_timestamps
+                if wt:
+                    all_words.extend(wt.words)
+                    all_starts.extend(wt.start)
+                    all_ends.extend(wt.end)
+
+        audio_data = b"".join(audio_chunks)
+        _validate_audio_response(audio_data, DEFAULT_OUTPUT_FORMAT)
+
+        # Timestamps should cover words from all transcripts
+        if all_words:
+            _validate_timestamps(all_words, all_starts, all_ends)
+            assert len(all_words) >= 4, f"Expected words from all transcripts, got {len(all_words)}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+@pytest.mark.filterwarnings("ignore::ResourceWarning")
+async def test_tts_websocket_context_reuse_async():
+    """Test reusing an async WebSocket context for multiple send/receive cycles.
+
+    Sends two separate rounds of transcripts on the same context (with
+    continue_=True), calls no_more_inputs once at the end, and validates that
+    audio is received for the full combined output.
+    """
+    logger.info("Testing async context reuse")
+
+    async with create_async_client() as client:
+        async with client.tts.websocket_connect() as connection:
+            ctx = connection.context(
+                model_id=DEFAULT_MODEL_ID,
+                voice={"mode": "id", "id": SAMPLE_VOICE_ID},
+                output_format=DEFAULT_OUTPUT_FORMAT,
+                language=SAMPLE_LANGUAGE,
+                add_timestamps=True,
+            )
+
+            # First round of transcripts
+            transcripts_round1 = ["Hello, world!", "How are you today?"]
+            for transcript in transcripts_round1:
+                await ctx.push(transcript)
+
+            # Second round of transcripts on the same context
+            transcripts_round2 = ["I am doing well.", "Thank you for asking."]
+            for transcript in transcripts_round2:
+                await ctx.push(transcript)
+
+            await ctx.no_more_inputs()
+
+            audio_chunks: list[bytes] = []
+            all_words: list[str] = []
+            all_starts: list[float] = []
+            all_ends: list[float] = []
+
+            async for response in ctx.receive():
+                if response.type == "chunk" and response.audio:
+                    audio_chunks.append(response.audio)
+                elif response.type == "timestamps":
+                    wt = response.word_timestamps
+                    if wt:
+                        all_words.extend(wt.words)
+                        all_starts.extend(wt.start)
+                        all_ends.extend(wt.end)
+
+            audio_data = b"".join(audio_chunks)
+            _validate_audio_response(audio_data, DEFAULT_OUTPUT_FORMAT)
+
+            # Timestamps should cover words from all transcripts
+            if all_words:
+                _validate_timestamps(all_words, all_starts, all_ends)
+                assert len(all_words) >= 4, f"Expected words from all transcripts, got {len(all_words)}"
+
+
+# ============================================================================
 # Voice Embedding Tests
 # ============================================================================
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -600,35 +600,28 @@ async def test_tts_websocket_concurrent_contexts_async():
                 output_format=DEFAULT_OUTPUT_FORMAT,
             )
 
-            async def send_to_ctx(ctx: AsyncWebSocketContext, text: str) -> None:
-                await ctx.push(text)
-                await ctx.no_more_inputs()
+            # Send to both contexts
+            await ctx1.push("Context one audio.")
+            await ctx1.no_more_inputs()
 
-            # Start sending concurrently
-            send_task1 = asyncio.create_task(send_to_ctx(ctx1, "Context one audio."))
-            send_task2 = asyncio.create_task(send_to_ctx(ctx2, "Context two audio."))
+            await ctx2.push("Context two audio.")
+            await ctx2.no_more_inputs()
 
-            # Receiver loop to demultiplex
-            audio1: list[bytes] = []
-            audio2: list[bytes] = []
-            active: set[str | None] = {ctx1._context_id, ctx2._context_id}
+            # Receive concurrently via ctx.receive()
+            async def collect(ctx: AsyncWebSocketContext) -> bytes:
+                chunks: list[bytes] = []
+                async for response in ctx.receive():
+                    if response.type == "chunk" and response.audio:
+                        chunks.append(response.audio)
+                return b"".join(chunks)
 
-            async for response in connection:
-                if response.type == "chunk" and response.audio:
-                    if response.context_id == ctx1._context_id:
-                        audio1.append(response.audio)
-                    elif response.context_id == ctx2._context_id:
-                        audio2.append(response.audio)
-                elif response.type == "done":
-                    if response.context_id in active:
-                        active.remove(response.context_id)
-                    if not active:
-                        break
+            audio1, audio2 = await asyncio.gather(
+                collect(ctx1),
+                collect(ctx2),
+            )
 
-            await asyncio.gather(send_task1, send_task2)
-
-            _validate_audio_response(b"".join(audio1), DEFAULT_OUTPUT_FORMAT)
-            _validate_audio_response(b"".join(audio2), DEFAULT_OUTPUT_FORMAT)
+            _validate_audio_response(audio1, DEFAULT_OUTPUT_FORMAT)
+            _validate_audio_response(audio2, DEFAULT_OUTPUT_FORMAT)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core WebSocket streaming/concurrency paths (dispatch, routing, reconnect, and context lifecycle), which can cause subtle deadlocks or event loss if incorrect, but changes are well-covered by new unit/integration tests.
> 
> **Overview**
> Fixes WebSocket TTS multi-context streaming by introducing per-context event queues and *lazy routing* so multiple contexts can safely call `ctx.receive()` (including concurrently in async) without losing or misattributing events.
> 
> Async connections now start a background dispatcher task to continuously drain the socket and fan-out events to context queues, add optional `timeout` support for receives, prevent duplicate `context_id` registration, and add `cancel()` plus default `add_timestamps`/`add_phoneme_timestamps` context settings.
> 
> Backcompat WebSocket `send(..., stream=False)` now returns a single aggregated result (audio + timestamps) and raises on `error` events; tests and examples were added/updated to cover concurrent receives, slow-reader isolation, flush, cancel, and context reuse scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a21183986b48999cf950509534d0df8b6d647b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->