### PR TITLE
feat: add X-Cartesia-Client on REST and WebSocket requests

### DIFF
--- a/src/cartesia/_base_client.py
+++ b/src/cartesia/_base_client.py
@@ -674,6 +674,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
             "Accept": "application/json",
             "Content-Type": "application/json",
             "User-Agent": self.user_agent,
+            "X-Cartesia-Client": self.client_header,
             **self.platform_headers(),
             **self.auth_headers,
             **self._custom_headers,
@@ -698,7 +699,11 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
 
     @property
     def user_agent(self) -> str:
-        return f"{self.__class__.__name__}/Python {self._version}"
+        return f"Cartesia/Python {self._version}"
+
+    @property
+    def client_header(self) -> str:
+        return f"cartesia-python/{self._version}"
 
     @property
     def base_url(self) -> URL:

--- a/src/cartesia/_base_client.py
+++ b/src/cartesia/_base_client.py
@@ -699,7 +699,7 @@ class BaseClient(Generic[_HttpxClientT, _DefaultStreamT]):
 
     @property
     def user_agent(self) -> str:
-        return f"Cartesia/Python {self._version}"
+        return self.client_header
 
     @property
     def client_header(self) -> str:

--- a/tests/lib/resources/stt/test_auto_finalize.py
+++ b/tests/lib/resources/stt/test_auto_finalize.py
@@ -81,6 +81,7 @@ def test_websocket_passes_auth_and_user_agent_headers(client: Cartesia, monkeypa
     ).enter()
     call = captured["calls"][0]
     assert call["user_agent_header"] == client.user_agent
+    assert call["additional_headers"]["X-Cartesia-Client"] == client.client_header
     assert call["additional_headers"]["X-Test"] == "1"
     # auth header from the client should be threaded through
     for key, value in client.auth_headers.items():

--- a/tests/lib/resources/stt/test_manual_finalize.py
+++ b/tests/lib/resources/stt/test_manual_finalize.py
@@ -116,6 +116,7 @@ def test_websocket_passes_auth_and_user_agent_headers(client: Cartesia, monkeypa
     ).enter()
     call = captured["calls"][0]
     assert call["user_agent_header"] == client.user_agent
+    assert call["additional_headers"]["X-Cartesia-Client"] == client.client_header
     assert call["additional_headers"]["X-Test"] == "1"
     for key, value in client.auth_headers.items():
         assert call["additional_headers"].get(key) == value

--- a/tests/lib/test_client_attribution.py
+++ b/tests/lib/test_client_attribution.py
@@ -2,14 +2,37 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 
 from cartesia import Cartesia, AsyncCartesia
+from cartesia._types import Omit
 
 from .resources.stt._fakes import FakeSyncWS, FakeAsyncWS, install_sync_connect, install_async_connect
 
 EXPECTED_USER_AGENT_PREFIX = "Cartesia/Python "
 EXPECTED_CLIENT_HEADER_PREFIX = "cartesia-python/"
+
+
+def _rest_default_headers(client: Cartesia) -> dict[str, str | Omit]:
+    return client.default_headers
+
+
+def _stt_auto_finalize_connect(client: Cartesia) -> None:
+    client.stt.auto_finalize.websocket(
+        encoding="pcm_s16le",
+        model="ink-2",
+        sample_rate=16_000,
+    ).enter()
+
+
+def _stt_manual_finalize_connect(client: Cartesia) -> None:
+    client.stt.manual_finalize.websocket(
+        encoding="pcm_s16le",
+        model="ink-2",
+        sample_rate=16_000,
+    ).enter()
 
 
 def _expected_identity(client: Cartesia | AsyncCartesia) -> tuple[str, str]:
@@ -25,13 +48,13 @@ def _expected_identity(client: Cartesia | AsyncCartesia) -> tuple[str, str]:
 @pytest.mark.parametrize(
     "service_name,get_headers",
     [
-        ("REST default_headers", lambda client: client.default_headers),
+        ("REST default_headers", _rest_default_headers),
     ],
 )
 def test_rest_identifies_as_cartesia_python(
     client: Cartesia,
     service_name: str,
-    get_headers,
+    get_headers: Callable[[Cartesia], dict[str, str | Omit]],
 ) -> None:
     user_agent, client_header = _expected_identity(client)
     headers = get_headers(client)
@@ -52,29 +75,15 @@ def test_tts_websocket_identifies_as_cartesia_python(client: Cartesia, monkeypat
 @pytest.mark.parametrize(
     "service_name,connect",
     [
-        (
-            "STT auto-finalize WebSocket",
-            lambda client: client.stt.auto_finalize.websocket(
-                encoding="pcm_s16le",
-                model="ink-2",
-                sample_rate=16_000,
-            ).enter(),
-        ),
-        (
-            "STT manual-finalize WebSocket",
-            lambda client: client.stt.manual_finalize.websocket(
-                encoding="pcm_s16le",
-                model="ink-2",
-                sample_rate=16_000,
-            ).enter(),
-        ),
+        ("STT auto-finalize WebSocket", _stt_auto_finalize_connect),
+        ("STT manual-finalize WebSocket", _stt_manual_finalize_connect),
     ],
 )
 def test_stt_websocket_identifies_as_cartesia_python(
     client: Cartesia,
     monkeypatch: pytest.MonkeyPatch,
     service_name: str,
-    connect,
+    connect: Callable[[Cartesia], None],
 ) -> None:
     user_agent, client_header = _expected_identity(client)
     captured = install_sync_connect(monkeypatch, FakeSyncWS)

--- a/tests/lib/test_client_attribution.py
+++ b/tests/lib/test_client_attribution.py
@@ -1,0 +1,101 @@
+"""Assert cartesia-python identifies itself on every outbound API surface."""
+
+from __future__ import annotations
+
+import pytest
+
+from cartesia import AsyncCartesia, Cartesia
+
+from .resources.stt._fakes import FakeAsyncWS, FakeSyncWS, install_async_connect, install_sync_connect
+
+EXPECTED_USER_AGENT_PREFIX = "Cartesia/Python "
+EXPECTED_CLIENT_HEADER_PREFIX = "cartesia-python/"
+
+
+def _expected_identity(client: Cartesia | AsyncCartesia) -> tuple[str, str]:
+    user_agent = client.user_agent
+    client_header = client.client_header
+    assert user_agent.startswith(EXPECTED_USER_AGENT_PREFIX)
+    assert client_header.startswith(EXPECTED_CLIENT_HEADER_PREFIX)
+    assert user_agent.endswith(client._version)
+    assert client_header.endswith(client._version)
+    return user_agent, client_header
+
+
+@pytest.mark.parametrize(
+    "service_name,get_headers",
+    [
+        ("REST default_headers", lambda client: client.default_headers),
+    ],
+)
+def test_rest_identifies_as_cartesia_python(
+    client: Cartesia,
+    service_name: str,
+    get_headers,
+) -> None:
+    user_agent, client_header = _expected_identity(client)
+    headers = get_headers(client)
+    assert headers["User-Agent"] == user_agent, service_name
+    assert headers["X-Cartesia-Client"] == client_header, service_name
+
+
+def test_tts_websocket_identifies_as_cartesia_python(client: Cartesia, monkeypatch: pytest.MonkeyPatch) -> None:
+    user_agent, client_header = _expected_identity(client)
+    captured = install_sync_connect(monkeypatch, FakeSyncWS)
+    client.tts.websocket_connect().enter()
+    call = captured["calls"][0]
+    assert call["user_agent_header"] == user_agent
+    assert call["additional_headers"]["User-Agent"] == user_agent
+    assert call["additional_headers"]["X-Cartesia-Client"] == client_header
+
+
+@pytest.mark.parametrize(
+    "service_name,connect",
+    [
+        (
+            "STT auto-finalize WebSocket",
+            lambda client: client.stt.auto_finalize.websocket(
+                encoding="pcm_s16le",
+                model="ink-2",
+                sample_rate=16_000,
+            ).enter(),
+        ),
+        (
+            "STT manual-finalize WebSocket",
+            lambda client: client.stt.manual_finalize.websocket(
+                encoding="pcm_s16le",
+                model="ink-2",
+                sample_rate=16_000,
+            ).enter(),
+        ),
+    ],
+)
+def test_stt_websocket_identifies_as_cartesia_python(
+    client: Cartesia,
+    monkeypatch: pytest.MonkeyPatch,
+    service_name: str,
+    connect,
+) -> None:
+    user_agent, client_header = _expected_identity(client)
+    captured = install_sync_connect(monkeypatch, FakeSyncWS)
+    connect(client)
+    call = captured["calls"][0]
+    assert call["user_agent_header"] == user_agent, service_name
+    assert call["additional_headers"]["X-Cartesia-Client"] == client_header, service_name
+
+
+@pytest.mark.asyncio
+async def test_async_stt_websocket_identifies_as_cartesia_python(
+    async_client: AsyncCartesia,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user_agent, client_header = _expected_identity(async_client)
+    captured = install_async_connect(monkeypatch, FakeAsyncWS)
+    await async_client.stt.auto_finalize.websocket(
+        encoding="pcm_s16le",
+        model="ink-2",
+        sample_rate=16_000,
+    ).enter()
+    call = captured["calls"][0]
+    assert call["user_agent_header"] == user_agent
+    assert call["additional_headers"]["X-Cartesia-Client"] == client_header

--- a/tests/lib/test_client_attribution.py
+++ b/tests/lib/test_client_attribution.py
@@ -11,7 +11,6 @@ from cartesia._types import Omit
 
 from .resources.stt._fakes import FakeSyncWS, FakeAsyncWS, install_sync_connect, install_async_connect
 
-EXPECTED_USER_AGENT_PREFIX = "Cartesia/Python "
 EXPECTED_CLIENT_HEADER_PREFIX = "cartesia-python/"
 
 
@@ -38,10 +37,9 @@ def _stt_manual_finalize_connect(client: Cartesia) -> None:
 def _expected_identity(client: Cartesia | AsyncCartesia) -> tuple[str, str]:
     user_agent = client.user_agent
     client_header = client.client_header
-    assert user_agent.startswith(EXPECTED_USER_AGENT_PREFIX)
     assert client_header.startswith(EXPECTED_CLIENT_HEADER_PREFIX)
-    assert user_agent.endswith(client._version)
     assert client_header.endswith(client._version)
+    assert user_agent == client_header
     return user_agent, client_header
 
 

--- a/tests/lib/test_client_attribution.py
+++ b/tests/lib/test_client_attribution.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import pytest
 
-from cartesia import AsyncCartesia, Cartesia
+from cartesia import Cartesia, AsyncCartesia
 
-from .resources.stt._fakes import FakeAsyncWS, FakeSyncWS, install_async_connect, install_sync_connect
+from .resources.stt._fakes import FakeSyncWS, FakeAsyncWS, install_sync_connect, install_async_connect
 
 EXPECTED_USER_AGENT_PREFIX = "Cartesia/Python "
 EXPECTED_CLIENT_HEADER_PREFIX = "cartesia-python/"


### PR DESCRIPTION
Fixes https://linear.app/cartesia/issue/SUR-1270/cartesia-python-add-x-cartesia-client-on-rest-websocket

## Summary

Python SDK v3 already sent User-Agent on WebSocket handshakes, but attribution used a different string shape than `X-Cartesia-Client`. This unifies both to `cartesia-python/<version>` on every outbound path.

## Changes

- Add `client_header` property and include `X-Cartesia-Client: cartesia-python/<ver>` in `default_headers`
- Set `user_agent` to the same slug value as `client_header`
- Extend STT websocket header tests to assert the new header
- Add `tests/lib/test_client_attribution.py` covering REST, TTS WS, and STT sync/async WS

## Test plan

- [x] `uv run pytest tests/lib/test_client_attribution.py tests/lib/resources/stt/test_manual_finalize.py::test_websocket_passes_auth_and_user_agent_headers tests/lib/resources/stt/test_auto_finalize.py::test_websocket_passes_auth_and_user_agent_headers`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Header-only observability change; User-Agent format changes from class-based strings, which could affect downstream log parsers but not auth or request semantics.
> 
> **Overview**
> Adds **stable SDK attribution** on outbound traffic by introducing a `client_header` value (`cartesia-python/<version>`), sending it as **`X-Cartesia-Client`** on REST via `default_headers`, and aligning **`User-Agent`** with that same string instead of varying by sync/async client class name.
> 
> STT WebSocket tests now assert the new header on connect, and **`test_client_attribution.py`** covers REST default headers plus TTS/STT WebSocket (sync and async) identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcd970d86c2a836f8f314d1031d2fbf7d16ce5af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->