### PR TITLE
stt transcribe examples crash when more than 2 arguments are supp...

### DIFF
--- a/examples/async_examples.py
+++ b/examples/async_examples.py
@@ -477,7 +477,7 @@ async def stt_transcribe_async(client: AsyncCartesia, *args: str) -> None:
             print("Usage: stt_transcribe_async <audio_file> <language_code>")
             print("Example: stt_transcribe_async my_audio.wav en")
             sys.exit(1)
-        file_path, language = args
+        file_path, language, *_ = args
     else:
         file_path, language = await generate_sample_wav()
 

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -633,7 +633,7 @@ def stt_transcribe(client: Cartesia, *args: str) -> None:
             print("Usage: stt_transcribe <audio_file> <language_code>")
             print("Example: stt_transcribe my_audio.wav en")
             sys.exit(1)
-        file_path, language = args
+        file_path, language, *_ = args
     else:
         file_path, language = generate_sample_wav()
 


### PR DESCRIPTION
Fixes #88.

The STT transcribe examples unpacked command-line arguments with `file_path, language = args`, which raised `ValueError: too many values to unpack` whenever more than two arguments were supplied. I changed both the sync and async examples to use the starred pattern `file_path, language, *_ = args` so extra arguments are captured safely, consistent with the other examples in these files.

I could not run the full suite in my environment, but the lint and file-level checks I could run on the changed files pass; CI should confirm the rest.