### PR TITLE
test: cover async receive() context-queue cleanup on timeout

### DIFF
--- a/tests/lib/test_client_custom_code_patches.py
+++ b/tests/lib/test_client_custom_code_patches.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any
+import asyncio
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -8,6 +9,7 @@ import pytest
 from cartesia import Cartesia, AsyncCartesia
 from cartesia._types import Omit
 from cartesia._models import FinalRequestOptions
+from cartesia.lib._tts import AsyncWebSocketContext, AsyncTTSResourceConnection
 from cartesia._base_client import make_request_options
 
 
@@ -138,6 +140,31 @@ def test_stt_auto_finalize_websocket_query_omits_values(client: Cartesia, monkey
         "sample_rate": "16000",
         "keep": "1",
     }
+
+
+async def test_async_receive_cleans_up_context_queue_on_timeout() -> None:
+    """AsyncWebSocketContext.receive() must drop its per-context queue on timeout.
+
+    Before Python 3.11 ``asyncio.wait_for`` raises ``asyncio.TimeoutError`` (a distinct
+    class from the builtin ``TimeoutError``), so an ``except TimeoutError`` handler would
+    miss it and skip the ``finally`` cleanup — leaking the queue on the connection. The
+    handler catches both, so cleanup runs on every supported Python version.
+    """
+    # The connection only needs a real ``_context_queues`` dict; the underlying socket is
+    # never touched because ``receive()`` reads from the queue, not the wire.
+    connection = AsyncTTSResourceConnection(cast(Any, object()))
+    context_id = "ctx-timeout"
+    # Queue is never fed, so the receive loop hits its timeout.
+    connection._context_queues[context_id] = asyncio.Queue()
+
+    context = AsyncWebSocketContext(connection, context_id, timeout=0.01)
+
+    with pytest.raises((TimeoutError, asyncio.TimeoutError)):
+        async for _ in context.receive():
+            pass
+
+    # The per-context queue must be removed so it does not leak on the connection.
+    assert context_id not in connection._context_queues
 
 
 async def test_async_stt_auto_finalize_websocket_query_omits_values(


### PR DESCRIPTION
## What

Adds a regression test for the fix landed in #91.

`AsyncWebSocketContext.receive()` in `src/cartesia/lib/_tts.py` reads its per-context queue via `asyncio.wait_for(...)` and, on timeout, sets `done = True` so the `finally` block removes the context's queue from `self._connection._context_queues`. #91 changed the handler to catch **both** the builtin `TimeoutError` and `asyncio.TimeoutError`, because before Python 3.11 `asyncio.wait_for` raises the latter (a distinct class), so the old `except TimeoutError` missed it — `done` stayed `False`, cleanup was skipped, and the queue leaked on the connection after every receive timeout.

This PR adds a test so that behavior can't silently regress.

## Test

`test_async_receive_cleans_up_context_queue_on_timeout` in `tests/lib/test_client_custom_code_patches.py`:

- Builds a real `AsyncTTSResourceConnection` over a dummy socket (`receive()` reads from the per-context queue, not the wire, so the socket is never touched — no `# type: ignore` needed).
- Registers a context queue that is never fed and drives `receive()` with a small timeout.
- Asserts `receive()` raises **and** that the per-context queue is removed from `_context_queues`.

Offline — no API key or network. On Python 3.9/3.10 the cleanup assertion fails without the #91 fix; a no-op on 3.11+ where the two exception classes are aliases.

`pytest tests/lib/test_client_custom_code_patches.py` → 8 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds an **offline regression test** for the async TTS WebSocket fix from #91: when `AsyncWebSocketContext.receive()` times out waiting on its per-context queue, the entry must be removed from `AsyncTTSResourceConnection._context_queues`.
> 
> The test wires a dummy connection with an empty queue, drives `receive()` with a short timeout, expects a timeout exception, and asserts the context id is no longer in `_context_queues`. That guards against regressions on Python 3.9/3.10 where `asyncio.wait_for` raised `asyncio.TimeoutError` instead of builtin `TimeoutError`, which previously skipped cleanup and leaked queues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0f9516cc7b8e611f1bcea1d36a5575289c835ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->